### PR TITLE
Upgrade argo to 2.5.1 + remove CommonLabels

### DIFF
--- a/cert-manager/base/kustomization.yaml
+++ b/cert-manager/base/kustomization.yaml
@@ -4,13 +4,8 @@ resources:
  - cert-manager.yaml
  - certificate.yaml
  - cluster-issuer.yaml
-commonLabels:
-  app.kubernetes.io/name: cert-manager
-  app.kubernetes.io/instance: cert-manager-v0.11.0
-  app.kubernetes.io/managed-by: onepanel-cli
-  app.kubernetes.io/component: cert-manager
-  app.kubernetes.io/part-of: onepanel
-  app.kubernetes.io/version: v0.11.0
+transformers:
+- metadataLabelTransformer.yaml
 configMapGenerator:
  - name: cert-manager-config
    envs:

--- a/cert-manager/base/metadataLabelTransformer.yaml
+++ b/cert-manager/base/metadataLabelTransformer.yaml
@@ -1,0 +1,14 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: metadataLabelTransformer
+labels:
+  app.kubernetes.io/name: cert-manager
+  app.kubernetes.io/instance: cert-manager-v0.11.0
+  app.kubernetes.io/managed-by: onepanel-cli
+  app.kubernetes.io/component: cert-manager
+  app.kubernetes.io/part-of: onepanel
+  app.kubernetes.io/version: v0.11.0
+fieldSpecs:
+- path: metadata/labels
+  create: true

--- a/common/argo/base/deployment.yaml
+++ b/common/argo/base/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: argoproj/workflow-controller:v2.5.0-rc9
+        image: argoproj/workflow-controller:v2.5.1
         imagePullPolicy: IfNotPresent
         name: workflow-controller
         resources: {}

--- a/common/argo/base/kustomization.yaml
+++ b/common/argo/base/kustomization.yaml
@@ -7,13 +7,8 @@ resources:
 - crd.yaml
 - deployment.yaml
 - service-account.yaml
-commonLabels:
-  app.kubernetes.io/name: argo
-  app.kubernetes.io/instance: argo-v2.5.1
-  app.kubernetes.io/managed-by: onepanel-cli
-  app.kubernetes.io/component: argo
-  app.kubernetes.io/part-of: onepanel
-  app.kubernetes.io/version: v2.5.1
+transformers:
+- metadataLabelTransformer.yaml
 images:
 - name: argoproj/workflow-controller
   newName: argoproj/workflow-controller

--- a/common/argo/base/kustomization.yaml
+++ b/common/argo/base/kustomization.yaml
@@ -9,14 +9,14 @@ resources:
 - service-account.yaml
 commonLabels:
   app.kubernetes.io/name: argo
-  app.kubernetes.io/instance: argo-v2.5.0-rc9
+  app.kubernetes.io/instance: argo-v2.5.1
   app.kubernetes.io/managed-by: onepanel-cli
   app.kubernetes.io/component: argo
   app.kubernetes.io/part-of: onepanel
-  app.kubernetes.io/version: v2.5.0-rc9
+  app.kubernetes.io/version: v2.5.1
 images:
 - name: argoproj/workflow-controller
   newName: argoproj/workflow-controller
-  newTag: v2.5.0-rc9
+  newTag: v2.5.1
 configurations:
 - params.yaml

--- a/common/argo/base/metadataLabelTransformer.yaml
+++ b/common/argo/base/metadataLabelTransformer.yaml
@@ -1,0 +1,14 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: metadataLabelTransformer
+labels:
+  app.kubernetes.io/name: argo
+  app.kubernetes.io/instance: argo-v2.5.1
+  app.kubernetes.io/managed-by: onepanel-cli
+  app.kubernetes.io/component: argo
+  app.kubernetes.io/part-of: onepanel
+  app.kubernetes.io/version: v2.5.1
+fieldSpecs:
+- path: metadata/labels
+  create: true

--- a/common/argo/base/params.env
+++ b/common/argo/base/params.env
@@ -1,4 +1,4 @@
-executorImage=argoproj/argoexec:v2.5.0-rc9
+executorImage=argoproj/argoexec:v2.5.1
 containerRuntimeExecutor=docker
 artifactRepositoryKeyPrefix=artifacts
 artifactRepositoryInsecure=false

--- a/common/istio/base/kustomization.yaml
+++ b/common/istio/base/kustomization.yaml
@@ -2,10 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
  - istio.yaml
-commonLabels:
-  app.kubernetes.io/name: istio
-  app.kubernetes.io/instance: istio-v1.4.3
-  app.kubernetes.io/managed-by: onepanel-cli
-  app.kubernetes.io/component: istio
-  app.kubernetes.io/part-of: onepanel
-  app.kubernetes.io/version: v1.4.3
+transformers:
+- metadataLabelTransformer.yaml

--- a/common/istio/base/metadataLabelTransformer.yaml
+++ b/common/istio/base/metadataLabelTransformer.yaml
@@ -1,0 +1,14 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: metadataLabelTransformer
+labels:
+  app.kubernetes.io/name: istio
+  app.kubernetes.io/instance: istio-v1.4.3
+  app.kubernetes.io/managed-by: onepanel-cli
+  app.kubernetes.io/component: istio
+  app.kubernetes.io/part-of: onepanel
+  app.kubernetes.io/version: v1.4.3
+fieldSpecs:
+- path: metadata/labels
+  create: true

--- a/common/onepanel/base/kustomization.yaml
+++ b/common/onepanel/base/kustomization.yaml
@@ -11,10 +11,5 @@ resources:
  - database-secret.yaml
  - config-map.yaml
  - config-map-ns-scope.yaml
-commonLabels:
-  app.kubernetes.io/name: onepanel
-  app.kubernetes.io/instance: onepanel-v0.1.0
-  app.kubernetes.io/managed-by: onepanel-cli
-  app.kubernetes.io/component: onepanel
-  app.kubernetes.io/part-of: onepanel
-  app.kubernetes.io/version: v0.1.0
+transformers:
+  - metadataLabelTransformer.yaml

--- a/common/onepanel/base/metadataLabelTransformer.yaml
+++ b/common/onepanel/base/metadataLabelTransformer.yaml
@@ -1,0 +1,14 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: metadataLabelTransformer
+labels:
+  app.kubernetes.io/name: onepanel
+  app.kubernetes.io/instance: onepanel-v0.5.0
+  app.kubernetes.io/managed-by: onepanel-cli
+  app.kubernetes.io/component: onepanel
+  app.kubernetes.io/part-of: onepanel
+  app.kubernetes.io/version: v0.5.0
+fieldSpecs:
+- path: metadata/labels
+  create: true

--- a/logging/base/kustomization.yaml
+++ b/logging/base/kustomization.yaml
@@ -6,6 +6,5 @@ resources:
   - elasticsearch_statefulset.yaml
   - kibana.yaml
   - fluentd.yaml
-commonLabels:
-  app.kubernetes.io/managed-by: onepanel-cli
-  app.kubernetes.io/part-of: onepanel
+transformers:
+- metadataLabelTransformer.yaml

--- a/logging/base/metadataLabelTransformer.yaml
+++ b/logging/base/metadataLabelTransformer.yaml
@@ -1,0 +1,14 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: metadataLabelTransformer
+labels:
+  app.kubernetes.io/name: kibana
+  app.kubernetes.io/instance: kibana-v7.2.0
+  app.kubernetes.io/managed-by: onepanel-cli
+  app.kubernetes.io/component: kibana
+  app.kubernetes.io/part-of: onepanel
+  app.kubernetes.io/version: v7.2.0
+fieldSpecs:
+- path: metadata/labels
+  create: true

--- a/vars/workflow-config-map-hidden.env
+++ b/vars/workflow-config-map-hidden.env
@@ -1,4 +1,4 @@
-artifactRepositoryExecutorImage=argoproj/argoexec:v2.5.0-rc9
+artifactRepositoryExecutorImage=argoproj/argoexec:v2.5.1
 artifactRepositoryContainerRuntimeExecutor=docker
 artifactRepositoryKeyFormat=artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}
 artifactRepositoryAccessKeySecretName=onepanel


### PR DESCRIPTION
There are two main issues resolved here:
- Upgraded argo to 2.5.1
- Removed `CommonLabels` as they got injected into `Selectors`, see https://github.com/kubernetes-sigs/kustomize/issues/1009 for more info.