### PR TITLE
use PNS executor as it's more secure

### DIFF
--- a/common/argo/base/params.env
+++ b/common/argo/base/params.env
@@ -1,5 +1,5 @@
 executorImage=argoproj/argoexec:v2.5.1
-containerRuntimeExecutor=docker
+containerRuntimeExecutor=pns
 artifactRepositoryKeyPrefix=artifacts
 artifactRepositoryInsecure=false
 artifactRepositoryAccessKeySecretName=onepanel

--- a/common/onepanel/base/add-network-policy.yaml
+++ b/common/onepanel/base/add-network-policy.yaml
@@ -3,7 +3,7 @@ kind: NetworkPolicy
 metadata:
   labels:
     app: onepanel
-  name: default
+  name: onepanel
   namespace: $(defaultNamespace) # replace with relevant namespace
 spec:
   egress:

--- a/common/onepanel/base/add-role.yaml
+++ b/common/onepanel/base/add-role.yaml
@@ -10,6 +10,7 @@ rules:
   - ""
   resources:
   - pods
+  - pods/log
   verbs: ["get", "watch", "patch"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims", "services", "secrets"]

--- a/vars/workflow-config-map-hidden.env
+++ b/vars/workflow-config-map-hidden.env
@@ -1,5 +1,5 @@
 artifactRepositoryExecutorImage=argoproj/argoexec:v2.5.1
-artifactRepositoryContainerRuntimeExecutor=docker
+artifactRepositoryContainerRuntimeExecutor=pns
 artifactRepositoryKeyFormat=artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}
 artifactRepositoryAccessKeySecretName=onepanel
 artifactRepositoryAccessKeySecretKey=artifactRepositoryAccessKey


### PR DESCRIPTION
References:
https://github.com/argoproj/argo/blob/master/docs/workflow-executors.md
https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
