### PR TITLE
docs: add comments to document params.yaml fields

### DIFF
--- a/cert-manager/base/vars.yaml
+++ b/cert-manager/base/vars.yaml
@@ -1,6 +1,6 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Component: cert-manager
-# Description: automatically creates and renews TLS certficates using Let's Encrypt
+# Description: automatically creates and renews TLS certificates using Let's Encrypt
 # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 certManager:

--- a/cert-manager/base/vars.yaml
+++ b/cert-manager/base/vars.yaml
@@ -1,6 +1,8 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Component: cert-manager
 # Description: automatically creates and renews TLS certficates using Let's Encrypt
 # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 certManager:
   # Enter a wildcard domain name
   # Examples: *.example.com or *.subdomain.example.com

--- a/cert-manager/base/vars.yaml
+++ b/cert-manager/base/vars.yaml
@@ -1,7 +1,14 @@
+# Component: cert-manager
+# Description: automatically creates and renews TLS certficates using Let's Encrypt
+# Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls
 certManager:
+  # Enter a wildcard domain name
+  # Examples: *.example.com or *.subdomain.example.com
   commonName:
     required: true
     default: <wildcard-fqdn>
+  # Enter certificate admin email
+  # Example: admin@example.com
   email:
     required: true
     default: <cert-admin-email>

--- a/cert-manager/base/vars.yaml
+++ b/cert-manager/base/vars.yaml
@@ -2,6 +2,7 @@
 # Component: cert-manager
 # Description: automatically creates and renews TLS certificates using Let's Encrypt
 # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls
+# CLI flag: --enable-cert-manager
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 certManager:
   # Enter a wildcard domain name

--- a/cert-manager/overlays/azuredns/vars.yaml
+++ b/cert-manager/overlays/azuredns/vars.yaml
@@ -1,6 +1,7 @@
 certManager:
   # DNS Provider: AzureDNS
   # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls#azuredns
+  # CLI flag: --dns-provider=azuredns
   azuredns:
     clientId:
       required: true

--- a/cert-manager/overlays/azuredns/vars.yaml
+++ b/cert-manager/overlays/azuredns/vars.yaml
@@ -1,4 +1,6 @@
 certManager:
+  # DNS Provider: AzureDNS
+  # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls#azuredns
   azuredns:
     clientId:
       required: true

--- a/cert-manager/overlays/clouddns/vars.yaml
+++ b/cert-manager/overlays/clouddns/vars.yaml
@@ -1,6 +1,7 @@
 certManager:
   # DNS Provider: Google CloudDNS
   # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls#google-clouddns
+  # CLI flag: --dns-provider=clouddns
   clouddns:
     projectId:
       required: true

--- a/cert-manager/overlays/clouddns/vars.yaml
+++ b/cert-manager/overlays/clouddns/vars.yaml
@@ -1,4 +1,6 @@
 certManager:
+  # DNS Provider: Google CloudDNS
+  # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls#google-clouddns
   clouddns:
     projectId:
       required: true

--- a/cert-manager/overlays/cloudflare/vars.yaml
+++ b/cert-manager/overlays/cloudflare/vars.yaml
@@ -1,6 +1,7 @@
 certManager:
   # DNS Provider: Cloudflare
   # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls#cloudflare
+  # CLI flag: --dns-provider=cloudflare
   cloudflare:
     apiToken:
       required: true

--- a/cert-manager/overlays/cloudflare/vars.yaml
+++ b/cert-manager/overlays/cloudflare/vars.yaml
@@ -1,4 +1,6 @@
 certManager:
+  # DNS Provider: Cloudflare
+  # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls#cloudflare
   cloudflare:
     apiToken:
       required: true

--- a/cert-manager/overlays/route53/vars.yaml
+++ b/cert-manager/overlays/route53/vars.yaml
@@ -1,6 +1,7 @@
 certManager:
   # DNS Provider: Amazon Route53
   # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls#route53
+  # CLI flag: --dns-provider=route53
   route53:
     region:
       required: true

--- a/cert-manager/overlays/route53/vars.yaml
+++ b/cert-manager/overlays/route53/vars.yaml
@@ -1,4 +1,6 @@
 certManager:
+  # DNS Provider: Amazon Route53
+  # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls#route53
   route53:
     region:
       required: true

--- a/common/argo/base/deployment.yaml
+++ b/common/argo/base/deployment.yaml
@@ -18,9 +18,9 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v2.6.1
+        - argoproj/argoexec:v2.6.3
         command:
         - workflow-controller
-        image: argoproj/workflow-controller:v2.6.1
+        image: argoproj/workflow-controller:v2.6.3
         name: workflow-controller
       serviceAccountName: argo

--- a/common/argo/base/kustomization.yaml
+++ b/common/argo/base/kustomization.yaml
@@ -12,6 +12,6 @@ transformers:
 images:
 - name: argoproj/workflow-controller
   newName: argoproj/workflow-controller
-  newTag: v2.6.1
+  newTag: v2.6.3
 configurations:
 - params.yaml

--- a/common/argo/base/metadataLabelTransformer.yaml
+++ b/common/argo/base/metadataLabelTransformer.yaml
@@ -4,11 +4,11 @@ metadata:
   name: metadataLabelTransformer
 labels:
   app.kubernetes.io/name: argo
-  app.kubernetes.io/instance: argo-v2.6.1
+  app.kubernetes.io/instance: argo-v2.6.3
   app.kubernetes.io/managed-by: onepanel-cli
   app.kubernetes.io/component: argo
   app.kubernetes.io/part-of: onepanel
-  app.kubernetes.io/version: v2.6.1
+  app.kubernetes.io/version: v2.6.3
 fieldSpecs:
 - path: metadata/labels
   create: true

--- a/common/argo/base/params.env
+++ b/common/argo/base/params.env
@@ -1,4 +1,4 @@
-executorImage=argoproj/argoexec:v2.6.1
+executorImage=argoproj/argoexec:v2.6.3
 containerRuntimeExecutor=pns
 artifactRepositoryKeyPrefix=artifacts
 artifactRepositoryInsecure=false

--- a/common/argo/base/vars.yaml
+++ b/common/argo/base/vars.yaml
@@ -1,19 +1,33 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Component: Artifact repository
+# Description: S3 compatible object storage for storing files across Onepanel
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 artifactRepository:
+  # S3 access key
   accessKey:
     required: true
     default: <access-key>
+  # S3 secret key
   secretKey:
     required: true
     default: <secret-key>
+  # Name of bucket, example: my-bucket
   bucket:
     required: true
     default: <bucket-name>
+  # Endpoint for S3 compatible storage
+  # Supported provider endpoints:
+  #   AWS: s3.amazonaws.com
+  #   GCS: storage.googleapis.com
+  #   Minio: my-minio-endpoint.default:9000
   endpoint:
     required: true
     default: s3.amazonaws.com
+  # Set to false if endpoint is HTTP only
   insecure:
     required: true
     default: false
+  # Bucket region
   region:
     required: true
     default: us-west-2

--- a/common/argo/base/vars.yaml
+++ b/common/argo/base/vars.yaml
@@ -23,7 +23,7 @@ artifactRepository:
   endpoint:
     required: true
     default: s3.amazonaws.com
-  # Set to false if endpoint is HTTP only
+  # Change to true if endpoint does NOT support HTTPS
   insecure:
     required: true
     default: false

--- a/common/onepanel/base/deployment-onepanelcore-onepanel.yaml
+++ b/common/onepanel/base/deployment-onepanelcore-onepanel.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: onepanel
       containers:
         - name: onepanel-core
-          image: onepanel/core:1.0.0-beta.1
+          image: onepanel/core:latest
           command: ["/bin/sh", "-c"]
           args: ["./core"]
           ports:

--- a/common/onepanel/base/deployment-onepanelcoreui-onepanel.yaml
+++ b/common/onepanel/base/deployment-onepanelcoreui-onepanel.yaml
@@ -16,7 +16,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: onepanel-core-ui
-          image: onepanel/core-ui:1.0.0-beta.1
+          image: onepanel/core-ui:latest
           command:
             - "/bin/sh"
             - "-c"

--- a/common/onepanel/base/vars.yaml
+++ b/common/onepanel/base/vars.yaml
@@ -46,7 +46,7 @@ application:
     required: true
     default: default
   # Domain name or IP where Onepanel is hosted
-  # Use an IP address if you're running Onepanel locally
+  # Use an IP address if running local, use `minikube ip` or `multipass list` to get this IP
   # In the cloud, use a first-level or multi-level subdomain like app.example.com or app.sub.example.com
   host:
     required: true

--- a/common/onepanel/base/vars.yaml
+++ b/common/onepanel/base/vars.yaml
@@ -2,8 +2,10 @@
 defaultNamespace:
   required: true
   default: default
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Component: Database
 # Description: Database connection information
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 database:
   # Database host - use `postgres` to use in cluster database for testing
   host:
@@ -35,8 +37,10 @@ database:
   driverName:
     required: true
     default: postgres
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Component: Onepanel
 # Description: Onepanel application information
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 application:
   defaultNamespace:
     required: true

--- a/common/onepanel/base/vars.yaml
+++ b/common/onepanel/base/vars.yaml
@@ -1,26 +1,49 @@
+# First namespace that will be created in Onepanel, more can be added later
+defaultNamespace:
+  required: true
+  default: default
+# Component: Database
+# Description: Database connection information
 database:
+  # Database host - use `postgres` to use in cluster database for testing
   host:
     required: true
     default: <database-ip-or-hostname>
+  # Database username
+  # If using an external production database, use the username for that database.
+  # For in-cluster test database, use any username you like.
   username:
     required: true
     default: <username>
+  # Database password
+  # If using an external production database, use the password for that database.
+  # For in-cluster test database, use any password you like.
   password:
     required: true
     default: <password>
+  # Database port
   port:
     required: true
     default: 5432
+  # Name of database
+  # If using an external production database, use the name of that database.
+  # For in-cluster test database, use any name you like.
   databaseName:
     required: true
     default: onepanel
+  # Do not change, only `postgres` driver is supported at this time.
   driverName:
     required: true
     default: postgres
+# Component: Onepanel
+# Description: Onepanel application information
 application:
   defaultNamespace:
     required: true
     default: default
+  # Domain name or IP where Onepanel is hosted
+  # Use an IP address if you're running Onepanel locally
+  # In the cloud, use a first-level or multi-level subdomain like app.example.com or app.sub.example.com
   host:
     required: true
     default: <ip-or-fqdn>

--- a/common/onepanel/base/vars.yaml
+++ b/common/onepanel/base/vars.yaml
@@ -7,7 +7,7 @@ defaultNamespace:
 # Description: Database connection information
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 database:
-  # Database host - use `postgres` to use in cluster database for testing
+  # Database host - use `postgres` for in-cluster test database
   host:
     required: true
     default: <database-ip-or-hostname>
@@ -77,7 +77,7 @@ application:
     apiGRPCPort:
       required: true
       default: 8887
-    # HTTP or HTTPS - Do not change as this is determined byt `opctl init`
+    # HTTP or HTTPS - Do not change as this is determined by `opctl init`
     insecure:
       required: true
       default: false

--- a/common/onepanel/base/vars.yaml
+++ b/common/onepanel/base/vars.yaml
@@ -77,7 +77,8 @@ application:
     apiGRPCPort:
       required: true
       default: 8887
-    # HTTP or HTTPS - Do not change as this is determined by `opctl init`
+    # HTTP or HTTPS - Do not change, determined by `opctl init --enable-https`
+    # CLI flag: --enable-https
     insecure:
       required: true
       default: false

--- a/common/onepanel/base/vars.yaml
+++ b/common/onepanel/base/vars.yaml
@@ -48,25 +48,32 @@ application:
     required: true
     default: <ip-or-fqdn>
   local:
+    # HTTP port for API
     apiHTTPPort:
       required: true
       default: 32000
+    # GRPC port for API
     apiGRPCPort:
       required: true
       default: 32001
+    # HTTP port for UI
     uiHTTPPort:
       required: true
       default: 32002
   cloud:
+    # Path of UI relative to host
     uiPath:
       required: true
       default: /
+    # Path of API relative to host
     apiPath:
       required: true
       default: /api
+    # GRPC port for API
     apiGRPCPort:
       required: true
       default: 8887
+    # HTTP or HTTPS - Do not change as this is determined byt `opctl init`
     insecure:
       required: true
       default: false

--- a/common/onepanel/base/vars.yaml
+++ b/common/onepanel/base/vars.yaml
@@ -1,7 +1,3 @@
-# First namespace that will be created in Onepanel, more can be added later
-defaultNamespace:
-  required: true
-  default: default
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Component: Database
 # Description: Database connection information
@@ -42,6 +38,7 @@ database:
 # Description: Onepanel application information
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 application:
+  # First namespace that will be created in Onepanel, more can be added later
   defaultNamespace:
     required: true
     default: default

--- a/logging/base/vars.yaml
+++ b/logging/base/vars.yaml
@@ -1,7 +1,13 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Component: Application and system logging
+# Description: ElasticSearch, Fluentd and Kibana (EFK) logging
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 logging:
+  # ElasticSearch container image
   image:
     required: false
     default: docker.elastic.co/elasticsearch/elasticsearch:7.6.0
+  # Volume size for EFK logging
   volumeStorage:
     required: false
     default: 100Gi

--- a/logging/base/vars.yaml
+++ b/logging/base/vars.yaml
@@ -1,6 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Component: Application and system logging
 # Description: ElasticSearch, Fluentd and Kibana (EFK) logging
+# CLI flag: --enable-efk-logging
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 logging:
   # ElasticSearch container image

--- a/vars/workflow-config-map-hidden.env
+++ b/vars/workflow-config-map-hidden.env
@@ -1,4 +1,4 @@
-artifactRepositoryExecutorImage=argoproj/argoexec:v2.6.1
+artifactRepositoryExecutorImage=argoproj/argoexec:v2.6.3
 artifactRepositoryContainerRuntimeExecutor=pns
 artifactRepositoryKeyFormat=artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}
 artifactRepositoryAccessKeySecretName=onepanel


### PR DESCRIPTION
```yaml
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
# Component: Onepanel
# Description: Onepanel application information
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
application:
  cloud:
    # GRPC port for API
    apiGRPCPort: 8887
    # Path of API relative to host
    apiPath: /api
    # HTTP or HTTPS - Do not change, determined by `opctl init --enable-https`
    # CLI flag: --enable-https
    insecure: false
    # Path of UI relative to host
    uiPath: /
  # First namespace that will be created in Onepanel, more can be added later
  defaultNamespace: default
  # Domain name or IP where Onepanel is hosted
  # Use an IP address if running local, use `minikube ip` or `multipass list` to get this IP
  # In the cloud, use a first-level or multi-level subdomain like app.example.com or app.sub.example.com
  host: <ip-or-fqdn>
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
# Component: Artifact repository
# Description: S3 compatible object storage for storing files across Onepanel
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
artifactRepository:
  # S3 access key
  accessKey: <access-key>
  # Name of bucket, example: my-bucket
  bucket: <bucket-name>
  # Endpoint for S3 compatible storage
  # Supported provider endpoints:
  #   AWS: s3.amazonaws.com
  #   GCS: storage.googleapis.com
  #   Minio: my-minio-endpoint.default:9000
  endpoint: s3.amazonaws.com
  # Change to true if endpoint does NOT support HTTPS
  insecure: false
  # Bucket region
  region: us-west-2
  # S3 secret key
  secretKey: <secret-key>
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
# Component: cert-manager
# Description: automatically creates and renews TLS certificates using Let's Encrypt
# Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls
# CLI flag: --enable-cert-manager
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
certManager:
  # DNS Provider: Google CloudDNS
  # Docs: https://onepanelio.github.io/core-docs/docs/deployment/configuration/tls#google-clouddns
  # CLI flag: --dns-provider=clouddns
  clouddns:
    projectId: <project-id>
    serviceAccountKey: <key.json-file-data>
  # Enter a wildcard domain name
  # Examples: *.example.com or *.subdomain.example.com
  commonName: <wildcard-fqdn>
  # Enter certificate admin email
  # Example: admin@example.com
  email: <cert-admin-email>
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
# Component: Database
# Description: Database connection information
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
database:
  # Name of database
  # If using an external production database, use the name of that database.
  # For in-cluster test database, use any name you like.
  databaseName: onepanel
  # Do not change, only `postgres` driver is supported at this time.
  driverName: postgres
  # Database host - use `postgres` for in-cluster test database
  host: <database-ip-or-hostname>
  # Database password
  # If using an external production database, use the password for that database.
  # For in-cluster test database, use any password you like.
  password: <password>
  # Database port
  port: 5432
  # Database username
  # If using an external production database, use the username for that database.
  # For in-cluster test database, use any username you like.
  username: <username>
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
# Component: Application and system logging
# Description: ElasticSearch, Fluentd and Kibana (EFK) logging
# CLI flag: --enable-efk-logging
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
logging:
  # ElasticSearch container image
  image: docker.elastic.co/elasticsearch/elasticsearch:7.6.0
  # Volume size for EFK logging
  volumeStorage: 100Gi
```