### PR TITLE
Adding ONEPANEL_API_URL and PROVIDER_TYPE to onepanel configmap.

### DIFF
--- a/common/onepanel/base/configmap-onepanel-onepanel.yaml
+++ b/common/onepanel/base/configmap-onepanel-onepanel.yaml
@@ -4,6 +4,8 @@ metadata:
   name: onepanel
   namespace: onepanel
 data:
+  onepanelApiUrl: $(onepanelApiUrl)
+  providerType: $(providerType)
   databaseHost: $(databaseHost)
   databasePort: $(databasePort)
   databaseName: $(databaseDatabaseName)

--- a/common/onepanel/base/configmap-onepanel-onepanel.yaml
+++ b/common/onepanel/base/configmap-onepanel-onepanel.yaml
@@ -4,8 +4,8 @@ metadata:
   name: onepanel
   namespace: onepanel
 data:
-  onepanelApiUrl: $(onepanelApiUrl)
-  providerType: $(providerType)
+  ONEPANEL_API_URL: $(onepanelApiUrl)
+  PROVIDER_TYPE: $(providerType)
   databaseHost: $(databaseHost)
   databasePort: $(databasePort)
   databaseName: $(databaseDatabaseName)


### PR DESCRIPTION
- These will be used by CORE to be injected as ENV Vars.

closes #https://github.com/onepanelio/core/issues/109