### PR TITLE
Using newer version of argoproj because this version supports

### DIFF
--- a/common/argo/base/deployment.yaml
+++ b/common/argo/base/deployment.yaml
@@ -18,9 +18,9 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v2.6.3
+        - argoproj/argoexec:v2.7.0
         command:
         - workflow-controller
-        image: argoproj/workflow-controller:v2.6.3
+        image: argoproj/workflow-controller:v2.7.0
         name: workflow-controller
       serviceAccountName: argo

--- a/common/argo/base/kustomization.yaml
+++ b/common/argo/base/kustomization.yaml
@@ -12,6 +12,6 @@ transformers:
 images:
 - name: argoproj/workflow-controller
   newName: argoproj/workflow-controller
-  newTag: v2.6.3
+  newTag: v2.7.0
 configurations:
 - params.yaml

--- a/common/argo/base/metadataLabelTransformer.yaml
+++ b/common/argo/base/metadataLabelTransformer.yaml
@@ -4,11 +4,11 @@ metadata:
   name: metadataLabelTransformer
 labels:
   app.kubernetes.io/name: argo
-  app.kubernetes.io/instance: argo-v2.6.3
+  app.kubernetes.io/instance: argo-v2.7.0
   app.kubernetes.io/managed-by: onepanel-cli
   app.kubernetes.io/component: argo
   app.kubernetes.io/part-of: onepanel
-  app.kubernetes.io/version: v2.6.3
+  app.kubernetes.io/version: v2.7.0
 fieldSpecs:
 - path: metadata/labels
   create: true

--- a/common/argo/base/params.env
+++ b/common/argo/base/params.env
@@ -1,4 +1,4 @@
-executorImage=argoproj/argoexec:v2.6.3
+executorImage=argoproj/argoexec:v2.7.0
 containerRuntimeExecutor=pns
 artifactRepositoryKeyPrefix=artifacts
 artifactRepositoryInsecure=false

--- a/vars/workflow-config-map-hidden.env
+++ b/vars/workflow-config-map-hidden.env
@@ -1,4 +1,4 @@
-artifactRepositoryExecutorImage=argoproj/argoexec:v2.6.3
+artifactRepositoryExecutorImage=argoproj/argoexec:v2.7.0
 artifactRepositoryContainerRuntimeExecutor=pns
 artifactRepositoryKeyFormat=artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}
 artifactRepositoryAccessKeySecretName=onepanel


### PR DESCRIPTION
passing metadata from CronWorkflows to Workflow Executions.

closes https://github.com/onepanelio/core/issues/134