### PR TITLE
update: removed application.cloud vars

### DIFF
--- a/common/onepanel/base/vars.yaml
+++ b/common/onepanel/base/vars.yaml
@@ -52,6 +52,11 @@ application:
   fqdn:
     required: true
     default: <fully-qualified-domain-name>
+  # HTTP or HTTPS - Do not change, determined by `opctl init --enable-https`
+  # CLI flag: --enable-https
+  insecure:
+    required: true
+    default: false
   local:
     # HTTP port for API
     apiHTTPPort:
@@ -65,24 +70,6 @@ application:
     uiHTTPPort:
       required: true
       default: 32002
-  cloud:
-    # Path of UI relative to host
-    uiPath:
-      required: true
-      default: /
-    # Path of API relative to host
-    apiPath:
-      required: true
-      default: /api
-    # GRPC port for API
-    apiGRPCPort:
-      required: true
-      default: 8887
-    # HTTP or HTTPS - Do not change, determined by `opctl init --enable-https`
-    # CLI flag: --enable-https
-    insecure:
-      required: true
-      default: false
   # Node pool or group label keys and values used for AutoScaling and for NodeSelectors
   # The provider will set these label key and values on your nodes automatically
   # These can also be customized depending on your provider

--- a/vars/onepanel-config-map-hidden.env
+++ b/vars/onepanel-config-map-hidden.env
@@ -1,0 +1,3 @@
+applicationCloudUiPath: /
+applicationCloudApiPath: /api
+applicationCloudApiGRPCPort: 8887


### PR DESCRIPTION
moved applicationCloud variables into their own variables files that are not configurable.

moved insecure to be directly under application

closes onepanelio/core#287 (along with cli PR)