### PR TITLE
feat: add permissions to support migrations

### DIFF
--- a/common/onepanel/base/clusterrole-onepanel.yaml
+++ b/common/onepanel/base/clusterrole-onepanel.yaml
@@ -10,6 +10,7 @@ rules:
   resources:
   - pods
   - pods/exec
+  - namespaces
   verbs:
   - create
   - get

--- a/common/onepanel/base/role-onepanel-defaultnamespace.yaml
+++ b/common/onepanel/base/role-onepanel-defaultnamespace.yaml
@@ -19,5 +19,5 @@ rules:
     resources: ["virtualservices"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["argoproj.io"]
-    resources: ["workflows","workflowtemplates"]
+    resources: ["workflows"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]

--- a/common/onepanel/base/role-onepanel-defaultnamespace.yaml
+++ b/common/onepanel/base/role-onepanel-defaultnamespace.yaml
@@ -19,5 +19,5 @@ rules:
     resources: ["virtualservices"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["argoproj.io"]
-    resources: ["workflows"]
+    resources: ["workflows","workflowtemplates"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]


### PR DESCRIPTION
What type of PR is this?

/kind enhancement

What this PR does:
This PR gives onepanel cluster wide access to namespaces.
- All of the verb operations (get, list, delete, etc.).
We need this for running the workspace template migrations. Specifically, to add new templates.
- The code needs to list namespaces in the k8s cluster
Per discussion, the intent is for our application to run in it's own cluster.

Which issue(s) this PR fixes:

closes https://github.com/onepanelio/core/issues/317

Special notes for your reviewer:
Pull down this manifest branch locally.
Ensure your configuration in your CLI project is this:
`.onepanel/cli_config.yaml`
```
manifestSource:
  directory:
    folder: /home/aleksandr/Code/onepanelio/manifests
    overrideCache: true
```
Where folder is your local path to the manifests repository.

Run `opctl init -p [provider] [..]` to get the latest changes pulled from manifests.
Then, run `opctl apply` for the role changes to take affect.

This is enough to apply these role changes.