### PR TITLE
fix: Migrations from go files need workflowtemplates access

### DIFF
--- a/common/onepanel/base/role-onepanel-defaultnamespace.yaml
+++ b/common/onepanel/base/role-onepanel-defaultnamespace.yaml
@@ -21,3 +21,6 @@ rules:
   - apiGroups: ["argoproj.io"]
     resources: ["workflows"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["workflowtemplates"]
+    verbs: ["create", "delete"]

--- a/common/onepanel/base/rolebinding-onepanel-defaultnamespace.yaml
+++ b/common/onepanel/base/rolebinding-onepanel-defaultnamespace.yaml
@@ -14,3 +14,6 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: $(applicationDefaultNamespace) # replace with relevant namespace
+- kind: ServiceAccount
+  name: onepanel
+  namespace: onepanel


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does**:
When the onepanel-core pod tried to execute the new jupyter and cvat migrations, it would fail.
The ServiceAccount that the pod ran under didn't have the right permissions to create argo
WorkflowTemplates.

**Special notes for your reviewer**:
Pull down this manifest.
Apply to your cluster.
See if onepanel-core pod throws an error on start-up.