### PR TITLE
chore: removed fqdn from header for workspaces

### DIFF
--- a/common/onepanel/overlays/cloud/istio-envoyfilter-istioingressgatewayauth-istio-system.yaml
+++ b/common/onepanel/overlays/cloud/istio-envoyfilter-istioingressgatewayauth-istio-system.yaml
@@ -32,7 +32,6 @@ spec:
               [":method"] = "HEAD",
               [":path"] = "/apis/v1beta1/auth/token",
               [":authority"] = "onepanel-core.onepanel.svc.local",
-              ["grpc-metadata-fqdn"] = "$(applicationFqdn)",
               ["grpc-metadata-x-original-method"] = request_handle:headers():get(":method"),
               ["grpc-metadata-x-original-authority"] = request_handle:headers():get(":authority"),
               ["grpc-metadata-x-original-uri"] = request_handle:headers():get(":path")


### PR DESCRIPTION
**What this PR does**:

Removes the fqdn from the header of workspaces requests.
It is not needed and should be checked by the API anyway.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#266

**Special notes for your reviewer**:
