### PR TITLE
feat: allow service account to list namespaces

### DIFF
--- a/common/onepanel/base/clusterrolebinding-onepanel-namespaces-defaultnamespace.yaml
+++ b/common/onepanel/base/clusterrolebinding-onepanel-namespaces-defaultnamespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: onepanel
+  name: onepanel-namespaces
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: onepanel-namespaces
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: $(applicationDefaultNamespace)
+

--- a/common/onepanel/base/clustetrrole-onepanel-namespaces.yaml
+++ b/common/onepanel/base/clustetrrole-onepanel-namespaces.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: onepanel
+  name: onepanel-namespaces
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list

--- a/common/onepanel/base/kustomization.yaml
+++ b/common/onepanel/base/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
  - crd.yaml
  - clusterrole-onepanel.yaml
  - clusterrolebinding-onepanel.yaml
+ - clustetrrole-onepanel-namespaces.yaml
+ - clusterrolebinding-onepanel-namespaces-defaultnamespace.yaml
  - configmap-onepanel-defaultnamespace.yaml
  - configmap-onepanel-onepanel.yaml
  - deployment-onepanelcore-onepanel.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:
Add `ClusterRole` and `ClusterRoleBinding` to allow service account in default namespace to get list of available namespaces.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->

**Special notes for your reviewer**:
This change allows Workflows and Workspace to be launched with default service account token from within Onepanel via SDK.
